### PR TITLE
Header improvements

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -141,7 +141,7 @@ function ButtonsDemo() {
 function HeaderDemo() {
   return (
     <Header>
-      <HeaderButtonMenu buttonChild="Menu">
+      <HeaderButtonMenu buttonChild="Menu" topLock={100}>
         <ModalMenuLink href="/">Link 1</ModalMenuLink>
         <ModalMenuLink href="/">Link 2</ModalMenuLink>
         <ModalMenuLink href="/">Link 3</ModalMenuLink>

--- a/src/Header.js
+++ b/src/Header.js
@@ -57,9 +57,11 @@ export function HeaderLink({ children, href, onClick }: {
   );
 }
 
-export class HeaderButtonMenu extends React.Component<{
-  buttonChild: React.Node, children: React.Node, hasArrow?: boolean,
-}, { showOptions: boolean }> {
+export class HeaderButtonMenu extends React.Component<{ buttonChild: React.Node,
+                                                        children: React.Node,
+                                                        topLock?: number,
+                                                        hasArrow?: boolean,},
+                                                      { showOptions: boolean }> {
   state = {
     showOptions: false,
   };
@@ -90,7 +92,7 @@ export class HeaderButtonMenu extends React.Component<{
         </HeaderButton>
         <div className="options">
           {state.showOptions ? (
-            <ModalMenu onClose={toggleShowOptions} topLock={70}>
+            <ModalMenu onClose={toggleShowOptions} topLock={props.topLock || 70}>
               {childrenWithToggler}
             </ModalMenu>
           ): null}


### PR DESCRIPTION
Added possibility to manage mobile menu modal top padding

Currently, as issue see small and unclear area of modal closing - top padding. Looks like we could add to it area below menu items, but it still will be unclear... Or some button...?